### PR TITLE
Replace use of deprecated items

### DIFF
--- a/lib/commands/HelloAutomation.ts
+++ b/lib/commands/HelloAutomation.ts
@@ -46,7 +46,7 @@ export class HelloAutomation implements HandleCommand {
     @Value("environment")
     private readonly environment: string;
 
-    public handle(ctx: HandlerContext): Promise<HandlerResult> {
+    public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         const pkg = `${pj.name}:${pj.version}`;
         const atm = `${this.name}:${this.version}`;
         const name = (pkg === atm) ? pkg : `package ${pkg} automation ${atm}`;

--- a/lib/commands/HelloWorld.ts
+++ b/lib/commands/HelloWorld.ts
@@ -24,7 +24,6 @@ import {
     MappedParameter,
     MappedParameters,
     Parameter,
-    Success,
     success,
     Tags,
 } from "@atomist/automation-client";
@@ -49,16 +48,12 @@ export class HelloWorld implements HandleCommand {
     @MappedParameter(MappedParameters.SlackUserName)
     public slackUser: string;
 
-    public handle(ctx: HandlerContext): Promise<HandlerResult> {
+    public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         logger.debug(`incoming parameter was ${this.name}`);
-
-        if (!ctx.graphClient) {
-            return Promise.resolve(Success);
-        }
 
         return ctx.graphClient.query<Person.Query, Person.Variables>({
             name: "Person",
-            variables: { teamId: ctx.teamId, slackUser: this.slackUser },
+            variables: { slackUser: this.slackUser },
         })
             .then(result => {
                 if (result && result.ChatTeam && result.ChatTeam[0] && result.ChatTeam[0].members &&
@@ -66,7 +61,7 @@ export class HelloWorld implements HandleCommand {
 
                     return result.ChatTeam[0].members[0].person;
                 } else {
-                    return null;
+                    return undefined;
                 }
             })
             .then(person => {

--- a/lib/graphql/query/person.graphql
+++ b/lib/graphql/query/person.graphql
@@ -1,5 +1,5 @@
-query Person($teamId: ID!, $slackUser: String!) {
-  ChatTeam(id: $teamId) {
+query Person($slackUser: String!) {
+  ChatTeam {
     members(screenName: $slackUser) {
       person {
         forename

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@atomist/automation-client": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-0.21.2.tgz",
-      "integrity": "sha512-Iz+cZKWUNJk3fYP5+yyF+/VFmGTI6cySs9LyVjDy8NPH4K53vdNnUo4MCYHOxMistExFM3lTWxLu5z2k/t9pEQ==",
+      "version": "1.0.0-master.20180901185845",
+      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.0.0-master.20180901185845.tgz",
+      "integrity": "sha512-dHo7sEQXBVDGdd5ZYJ6l79yTgqFNaN4KRLMR+AXscFkJMAPqavPgUl9FZu2Z0ruoyt8RKepYDcRK0/fAMOj+xg==",
       "requires": {
         "@atomist/microgrammar": "^0.8.1",
         "@atomist/slack-messages": "^0.12.1",
@@ -46,6 +46,7 @@
         "@types/yargs": "^11.0.0",
         "apollo-cache-inmemory": "1.2.8",
         "apollo-client": "^2.4.0",
+        "apollo-link": "^1.2.2",
         "apollo-link-http": "^1.5.1",
         "app-root-path": "^2.0.1",
         "asciify": "^1.3.5",
@@ -66,6 +67,7 @@
         "flat": "^4.1.0",
         "fs-extra": "^7.0.0",
         "git-url-parse": "^10.0.1",
+        "glob": "^7.1.3",
         "glob-promise": "^3.3.0",
         "glob-stream": "^6.1.0",
         "graphql": "^0.13.2",
@@ -95,6 +97,7 @@
         "serialize-error": "^2.1.0",
         "shelljs": "^0.8.1",
         "source-map-support": "^0.5.9",
+        "sprintf-js": "^1.1.1",
         "stack-trace": "0.0.10",
         "stream-spigot": "^3.0.6",
         "strip-ansi": "^4.0.0",
@@ -107,9 +110,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.7.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
-          "integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
+          "version": "10.9.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
+          "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
         },
         "@types/shelljs": {
           "version": "0.8.0",
@@ -142,6 +145,19 @@
             "universalify": "^0.1.0"
           }
         },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "semver": {
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
@@ -160,6 +176,11 @@
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
           }
+        },
+        "sprintf-js": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+          "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
         }
       }
     },
@@ -179,7 +200,7 @@
     },
     "@atomist/tree-path": {
       "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@atomist/tree-path/-/tree-path-0.1.9.tgz",
+      "resolved": "http://registry.npmjs.org/@atomist/tree-path/-/tree-path-0.1.9.tgz",
       "integrity": "sha512-lDTCBAd8lJeWswipBHFDvVNj5AMcYgHEX7jd9yZJbuRii8cLXJVxOPTTyczmEtG367YzMSm61AKBzY7ucSE3Ow==",
       "requires": {
         "@atomist/microgrammar": "^0.7.0"
@@ -604,9 +625,9 @@
       "integrity": "sha512-pRs2gYF5yoKYrgSaira0DJqVg2tFuF+Qjp838xS7K+mJyY2jJzjsrl6y17GbIa4uMRogMbxs+ghNCvKg6XyNrA=="
     },
     "@types/uuid": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
-      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+      "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
       "requires": {
         "@types/node": "*"
       }
@@ -732,11 +753,11 @@
       }
     },
     "apollo-cache": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.15.tgz",
-      "integrity": "sha512-sbFln2YZOuJNryMMLdmQzFN70GdEPeQqekCTwFFrNi1mYrrNdI3++mFGmDs7ecIRexZ2yrgNHlAQYCO5cuROMg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.16.tgz",
+      "integrity": "sha512-gVWKYyXF0SlpMyZ/i//AthzyPjjmAVYciEjwepLqMzIf0+7bzIwekpHDuzME8jf4XQepXcNNY571+BRyYHysmg==",
       "requires": {
-        "apollo-utilities": "^1.0.19"
+        "apollo-utilities": "^1.0.20"
       }
     },
     "apollo-cache-inmemory": {
@@ -750,16 +771,16 @@
       }
     },
     "apollo-client": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.0.tgz",
-      "integrity": "sha512-gxzf4O2pZjBDemeiaf63SlpR/x3VVwKlThLRo0Y3m6QHdmQTmlnaxle4Z9HCzJFqx79xFESxYJpxYoojO40HjQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.1.tgz",
+      "integrity": "sha512-E6pQD+BwI1zboM9oX83yzH9BmBjJWU5pL36CpGC2+XaaBDc6UvrPtacxQsg/h7Fq5T5IKJoIhuBEWtefJIb9xg==",
       "requires": {
         "@types/async": "2.0.49",
         "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "^1.1.15",
+        "apollo-cache": "1.1.16",
         "apollo-link": "^1.0.0",
         "apollo-link-dedup": "^1.0.0",
-        "apollo-utilities": "^1.0.19",
+        "apollo-utilities": "1.0.20",
         "symbol-observable": "^1.0.2",
         "zen-observable": "^0.8.0"
       }
@@ -807,9 +828,9 @@
       }
     },
     "apollo-utilities": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.19.tgz",
-      "integrity": "sha512-pyVxizjIevHFfKhtc9FLEsGHmqiK0kHx1aBdJRUXDt+X+yjoVa/fVeCEo9t0NddGximemxxrQnq6lSkbIQvDlA==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.20.tgz",
+      "integrity": "sha512-2M4BJCyX/9UXGJFoV4sTnVTZ4Q29aM18Z1avDrwvlCGGwoRTz50sGBAfTiWnUnnNQyPIIJEYElScw46DgIu0Rg==",
       "requires": {
         "fast-json-stable-stringify": "^2.0.0"
       }
@@ -898,7 +919,7 @@
       "dependencies": {
         "chalk": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
           "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
           "requires": {
             "ansi-styles": "~0.2.0",
@@ -1384,9 +1405,9 @@
       }
     },
     "chardet": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.5.0.tgz",
-      "integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "child-process-promise": {
       "version": "2.2.1",
@@ -1547,6 +1568,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
+      "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
     },
     "common-tags": {
       "version": "1.7.2",
@@ -2466,13 +2492,23 @@
       }
     },
     "external-editor": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.1.tgz",
-      "integrity": "sha512-e1neqvSt5pSwQcFnYc6yfGuJD2Q4336cdbHs5VeUO0zTkqPbrHMyw2q1r47fpfLWbvIG8H8A6YO3sck7upTV6Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "requires": {
-        "chardet": "^0.5.0",
-        "iconv-lite": "^0.4.22",
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "extglob": {
@@ -2647,9 +2683,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.6.tgz",
-      "integrity": "sha512-xay/eYZGgdpb3rpugZj1HunNaPcqc6fud/RW7LNEQntvKzuRO4DDLL+MnJIbTHh6t3Kda3v2RvhY2doxUddnig==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
+      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
       "requires": {
         "debug": "^3.1.0"
       }
@@ -3365,23 +3401,23 @@
     },
     "graphql": {
       "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
+      "resolved": "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
       "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
       "requires": {
         "iterall": "^1.2.1"
       }
     },
     "graphql-anywhere": {
-      "version": "4.1.17",
-      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.17.tgz",
-      "integrity": "sha512-g+6qc83IK+YluKLkdvyp2TymdG3eaIyhLU9a+u7qDN02O6aANELrTd0J+yq/exqDjYEm4ANN38BbO6RxS8fJ3Q==",
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.18.tgz",
+      "integrity": "sha512-n0jsAEpGpQxsF0RDaxSjtEQdIP3tx2C3q++QuHYFyUl+4Npl5t64zFjWwO3ZhotxmTgs8zaSbZPVFpydn6k0dQ==",
       "requires": {
-        "apollo-utilities": "^1.0.19"
+        "apollo-utilities": "^1.0.20"
       }
     },
     "graphql-code-generator": {
       "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/graphql-code-generator/-/graphql-code-generator-0.8.21.tgz",
+      "resolved": "http://registry.npmjs.org/graphql-code-generator/-/graphql-code-generator-0.8.21.tgz",
       "integrity": "sha1-Nky5foI4MrI0jwv+3rlM5U/mRrE=",
       "requires": {
         "@types/prettier": "1.10.0",
@@ -3394,18 +3430,11 @@
         "prettier": "1.11.1",
         "request": "2.85.0",
         "strip-comments": "0.4.4"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.15.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
-        }
       }
     },
     "graphql-codegen-compiler": {
       "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/graphql-codegen-compiler/-/graphql-codegen-compiler-0.8.21.tgz",
+      "resolved": "http://registry.npmjs.org/graphql-codegen-compiler/-/graphql-codegen-compiler-0.8.21.tgz",
       "integrity": "sha1-VscWq7dufDBcX1C0aYy2xqL8g48=",
       "requires": {
         "@types/handlebars": "4.0.36",
@@ -3419,7 +3448,7 @@
     },
     "graphql-codegen-core": {
       "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.8.21.tgz",
+      "resolved": "http://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.8.21.tgz",
       "integrity": "sha1-Cknq4nTFXvP7iC2eGJz1oVLvLu0=",
       "requires": {
         "graphql-tag": "2.8.0",
@@ -3744,9 +3773,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.1.0.tgz",
-      "integrity": "sha512-f9K2MMx/G/AVmJSaZg2a+GVLRRmTdlGLbwxsibNd6yNTxXujqxPypjCnxnC0y4+Wb/rNY5KyKuq06AO5jrE+7w==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
       "requires": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
@@ -3754,7 +3783,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "lodash": "^4.17.10",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -4451,16 +4480,16 @@
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
     },
     "mime-types": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "~1.36.0"
       }
     },
     "mimic-fn": {
@@ -4564,7 +4593,7 @@
     },
     "moment": {
       "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "resolved": "http://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
       "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "ms": {
@@ -5627,7 +5656,7 @@
     },
     "request": {
       "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -5725,9 +5754,9 @@
       }
     },
     "rxjs": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
-      "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.1.tgz",
+      "integrity": "sha512-hRVfb1Mcf8rLXq1AZEjYpzBnQbO7Duveu1APXkWRTvqzhmkoQ40Pl2F9Btacx+gJCOqsMiugCGG4I2HPQgJRtA==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -7004,9 +7033,9 @@
       "optional": true
     },
     "winston": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.3.tgz",
-      "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
       "requires": {
         "async": "~1.0.0",
         "colors": "1.0.x",
@@ -7030,7 +7059,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "@atomist/automation-client": "^0.21.2",
+    "@atomist/automation-client": "^1.0.0-master.20180901185845",
     "@types/app-root-path": "^1.2.4",
     "app-root-path": "^2.0.1"
   },

--- a/test/commands/HelloWorld.test.ts
+++ b/test/commands/HelloWorld.test.ts
@@ -33,7 +33,7 @@ describe("HelloWorld", () => {
     const hello = new HelloWorld();
     hello.name = "Chance the Rapper";
     hello.slackUser = "LilChano";
-    const teamId = "T79TH";
+    const workspaceId = "A79TH";
     const forename = "Chancelor";
     const surname = "Bennett";
     const emptyResponse = Promise.resolve({
@@ -44,16 +44,13 @@ describe("HelloWorld", () => {
 
     it("should extract sender person", async () => {
         let responseMessage: string;
-        const ctx = {
+        const ctx: HandlerContext = {
             graphClient: {
                 query(opts: any): Promise<Person.Query> {
                     if (!opts.name || opts.name !== "Person") {
                         return emptyResponse;
                     }
                     if (!opts.variables || opts.variables.slackUser !== hello.slackUser) {
-                        return emptyResponse;
-                    }
-                    if (!opts.variables || opts.variables.teamId !== teamId) {
                         return emptyResponse;
                     }
                     return Promise.resolve({
@@ -74,8 +71,8 @@ describe("HelloWorld", () => {
                     return Promise.resolve(msg);
                 },
             },
-            teamId,
-        } as HandlerContext;
+            workspaceId,
+        } as any;
 
         const result = await hello.handle(ctx);
         assert(result.code === 0);
@@ -85,7 +82,7 @@ describe("HelloWorld", () => {
 
     it("should respond when no sender person found", async () => {
         let responseMessage: string;
-        const ctx = {
+        const ctx: HandlerContext = {
             graphClient: {
                 query(opts: any): Promise<Person.Query> {
                     return emptyResponse;
@@ -97,8 +94,8 @@ describe("HelloWorld", () => {
                     return Promise.resolve(msg);
                 },
             },
-            teamId,
-        } as HandlerContext;
+            workspaceId,
+        } as any;
 
         const result = await hello.handle(ctx);
         assert(result.code === 0);

--- a/test/events/NotifyOnPush.test.ts
+++ b/test/events/NotifyOnPush.test.ts
@@ -19,6 +19,7 @@ import * as assert from "power-assert";
 import {
     EventFired,
     HandlerContext,
+    SlackDestination,
 } from "@atomist/automation-client";
 
 import { NotifyOnPush } from "../../lib/events/NotifyOnPush";
@@ -35,7 +36,7 @@ describe("NotifyOnPush", () => {
     ];
 
     it("should send a notification to a channel", async () => {
-        const pushEvent = {
+        const pushEvent: EventFired<PushWithRepo.Subscription> = {
             data: {
                 Push: [{
                     after: {
@@ -46,18 +47,21 @@ describe("NotifyOnPush", () => {
                     },
                 }],
             },
-        } as EventFired<PushWithRepo.Subscription>;
+        } as any;
         let responseMessage: string;
         let responseChannels: string[];
-        const ctx = {
+        const ctx: HandlerContext = {
+            graphClient: {
+                query: () => Promise.resolve({ ChatTeam: [{ id: "T79TH" }] }),
+            },
             messageClient: {
-                addressChannels(msg: string, toChannels: string[]): Promise<any> {
+                send(msg: string, dest: SlackDestination): Promise<any> {
                     responseMessage = msg;
-                    responseChannels = toChannels;
+                    responseChannels = dest.channels;
                     return Promise.resolve(msg);
                 },
             },
-        } as HandlerContext;
+        } as any;
 
         const result = await nop.handle(pushEvent, ctx);
         assert(result.code === 0);
@@ -67,7 +71,7 @@ describe("NotifyOnPush", () => {
     });
 
     it("should send a notification to all repo channels", async () => {
-        const pushEvent = {
+        const pushEvent: EventFired<PushWithRepo.Subscription> = {
             data: {
                 Push: [{
                     after: {
@@ -78,18 +82,21 @@ describe("NotifyOnPush", () => {
                     },
                 }],
             },
-        } as EventFired<PushWithRepo.Subscription>;
+        } as any;
         let responseMessage: string;
         let responseChannels: string[];
-        const ctx = {
+        const ctx: HandlerContext = {
+            graphClient: {
+                query: () => Promise.resolve({ ChatTeam: [{ id: "T79TH" }] }),
+            },
             messageClient: {
-                addressChannels(msg: string, toChannels: string[]): Promise<any> {
+                send(msg: string, dest: SlackDestination): Promise<any> {
                     responseMessage = msg;
-                    responseChannels = toChannels;
+                    responseChannels = dest.channels;
                     return Promise.resolve(msg);
                 },
             },
-        } as HandlerContext;
+        } as any;
 
         const result = await nop.handle(pushEvent, ctx);
         assert(result.code === 0);
@@ -98,7 +105,7 @@ describe("NotifyOnPush", () => {
     });
 
     it("should send no notifications if no channels", async () => {
-        const pushEvent = {
+        const pushEvent: EventFired<PushWithRepo.Subscription> = {
             data: {
                 Push: [{
                     after: {
@@ -109,18 +116,21 @@ describe("NotifyOnPush", () => {
                     },
                 }],
             },
-        } as EventFired<PushWithRepo.Subscription>;
+        } as any;
         let responseMessage: string;
         let responseChannels: string[];
-        const ctx = {
+        const ctx: HandlerContext = {
+            graphClient: {
+                query: () => Promise.resolve({ ChatTeam: [{ id: "T79TH" }] }),
+            },
             messageClient: {
-                addressChannels(msg: string, toChannels: string[]): Promise<any> {
+                addressChannels(msg: string, dest: SlackDestination): Promise<any> {
                     responseMessage = msg;
-                    responseChannels = toChannels;
+                    responseChannels = dest.channels;
                     return Promise.resolve(msg);
                 },
             },
-        } as HandlerContext;
+        } as any;
 
         const result = await nop.handle(pushEvent, ctx);
         assert(result.code === 0);


### PR DESCRIPTION
The HelloWorld example had some outdated ideas, chief among them was
using the Atomist team/workspace ID as the Slack workspace ID.

The NotifyOnPush example was using the deprecated addressChannels
method rather than the send method.

Update tests and mocking as necessary.

Update automation-client to simplify imports.